### PR TITLE
Add LabelPayload event publisher and listeners

### DIFF
--- a/src/main/java/rotateit/config/ApplicationContext.java
+++ b/src/main/java/rotateit/config/ApplicationContext.java
@@ -1,0 +1,44 @@
+package rotateit.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.scheduling.support.TaskUtils;
+import rotateit.controller.LabelWebhookController;
+import rotateit.service.EventPublisher;
+import rotateit.service.github.label.OnLabelEventToPersistListener;
+import rotateit.service.github.label.OnLabelEventToViewListener;
+
+@Configuration
+public class ApplicationContext {
+
+    @Bean
+    public ApplicationEventMulticaster eventMulticaster() {
+        SimpleApplicationEventMulticaster eventMulticaster = new SimpleApplicationEventMulticaster();
+        eventMulticaster.setTaskExecutor(new SimpleAsyncTaskExecutor());
+        eventMulticaster.setErrorHandler(TaskUtils.LOG_AND_SUPPRESS_ERROR_HANDLER);
+        return eventMulticaster;
+    }
+
+    @Bean
+    public EventPublisher eventPublisher(ApplicationEventMulticaster applicationEventMulticaster) {
+        return new EventPublisher(applicationEventMulticaster);
+    }
+
+    @Bean
+    public LabelWebhookController labelWebhookController(EventPublisher eventPublisher) {
+        return new LabelWebhookController(eventPublisher);
+    }
+
+    @Bean
+    public OnLabelEventToPersistListener onLabelEventToPersistListener() {
+        return new OnLabelEventToPersistListener();
+    }
+
+    @Bean
+    public OnLabelEventToViewListener onLabelEventToViewListener() {
+        return new OnLabelEventToViewListener();
+    }
+}

--- a/src/main/java/rotateit/controller/LabelWebhookController.java
+++ b/src/main/java/rotateit/controller/LabelWebhookController.java
@@ -1,20 +1,31 @@
 package rotateit.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import rotateit.domain.github.label.LabelPayload;
+import rotateit.service.EventPublisher;
 
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
+import static rotateit.domain.github.label.LabelEvent.aLabelEvent;
 
 @RestController
 public class LabelWebhookController {
+
+    private final EventPublisher eventPublisher;
+
+    @Autowired
+    public LabelWebhookController(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
     @RequestMapping(value = "/api/github/labelWebhookRequest", method = POST, consumes = APPLICATION_JSON_VALUE)
     @ResponseStatus(OK)
     public void labelWebhookRequest(@RequestBody LabelPayload labelPayload) {
-
+        eventPublisher.publish(aLabelEvent(labelPayload));
     }
 }

--- a/src/main/java/rotateit/domain/github/label/LabelEvent.java
+++ b/src/main/java/rotateit/domain/github/label/LabelEvent.java
@@ -1,0 +1,20 @@
+package rotateit.domain.github.label;
+
+import org.springframework.context.ApplicationEvent;
+
+@SuppressWarnings("unchecked")
+public class LabelEvent extends ApplicationEvent {
+
+    private LabelEvent(LabelPayload labelPayload) {
+        super(labelPayload);
+    }
+
+    @Override
+    public LabelPayload getSource() {
+        return (LabelPayload) super.getSource();
+    }
+
+    public static LabelEvent aLabelEvent(LabelPayload labelPayload) {
+        return new LabelEvent(labelPayload);
+    }
+}

--- a/src/main/java/rotateit/service/EventPublisher.java
+++ b/src/main/java/rotateit/service/EventPublisher.java
@@ -1,0 +1,19 @@
+package rotateit.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.event.ApplicationEventMulticaster;
+
+public class EventPublisher {
+
+    private final ApplicationEventMulticaster eventMulticaster;
+
+    @Autowired
+    public EventPublisher(ApplicationEventMulticaster eventMulticaster) {
+        this.eventMulticaster = eventMulticaster;
+    }
+
+    public void publish(ApplicationEvent event) {
+        eventMulticaster.multicastEvent(event);
+    }
+}

--- a/src/main/java/rotateit/service/github/label/OnLabelEventToPersistListener.java
+++ b/src/main/java/rotateit/service/github/label/OnLabelEventToPersistListener.java
@@ -1,0 +1,11 @@
+package rotateit.service.github.label;
+
+import org.springframework.context.event.EventListener;
+import rotateit.domain.github.label.LabelEvent;
+
+public class OnLabelEventToPersistListener {
+
+    @EventListener
+    public void onEvent(LabelEvent labelEvent) {
+    }
+}

--- a/src/main/java/rotateit/service/github/label/OnLabelEventToViewListener.java
+++ b/src/main/java/rotateit/service/github/label/OnLabelEventToViewListener.java
@@ -1,0 +1,11 @@
+package rotateit.service.github.label;
+
+import org.springframework.context.event.EventListener;
+import rotateit.domain.github.label.LabelEvent;
+
+public class OnLabelEventToViewListener {
+
+    @EventListener
+    public void onEvent(LabelEvent labelEvent) {
+    }
+}

--- a/src/test/java/rotateit/controller/LabelWebhookControllerTest.java
+++ b/src/test/java/rotateit/controller/LabelWebhookControllerTest.java
@@ -4,14 +4,21 @@ import com.google.common.io.Resources;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import rotateit.domain.github.label.LabelEvent;
+import rotateit.service.EventPublisher;
 
-import java.io.IOException;
 import java.net.URL;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.fail;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Matchers.isA;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -19,9 +26,16 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standal
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class LabelWebhookControllerTest {
+    private static final String JSON_REQUEST_PATH = "/github/label/exampleLabelWebhookRequest.json";
+    private static final String JSON_REQUEST = getContent(JSON_REQUEST_PATH);
+    private static final String ENDPOINT = "/api/github/labelWebhookRequest";
     private MockMvc mockMvc;
 
-    private LabelWebhookController labelWebhookController = new LabelWebhookController();
+    @Mock
+    private EventPublisher publisher;
+
+    @InjectMocks
+    private LabelWebhookController labelWebhookController;
 
     @Before
     public void setUp() {
@@ -30,16 +44,31 @@ public class LabelWebhookControllerTest {
 
     @Test
     public void shouldAcceptAndConvertJsonPayloadToLabelPayloadObject() throws Exception {
-        String jsonPayload = getContent("/github/label/exampleLabelWebhookRequest.json");
-
-        mockMvc.perform(post("/api/github/labelWebhookRequest")
-            .contentType(APPLICATION_JSON)
-            .content(jsonPayload))
-            .andExpect(status().isOk());
+        performPostOf(JSON_REQUEST).andExpect(status().isOk());
     }
 
-    private String getContent(String resourcePath) throws IOException {
-        URL filePath = new ClassPathResource(resourcePath).getURL();
-        return Resources.toString(filePath, UTF_8);
+    @Test
+    public void shouldPublishLabelPayload() throws Exception {
+        performPostOf(JSON_REQUEST);
+
+        then(publisher).should().publish(isA(LabelEvent.class));
+    }
+
+    private ResultActions performPostOf(String jsonPayload) throws Exception {
+        return mockMvc.perform(post(ENDPOINT)
+            .contentType(APPLICATION_JSON)
+            .content(jsonPayload));
+    }
+
+    private static String getContent(String resourcePath) {
+        URL filePath;
+        String resource = null;
+        try {
+            filePath = new ClassPathResource(resourcePath).getURL();
+            resource = Resources.toString(filePath, UTF_8);
+        } catch (Exception e) {
+            fail("Reading and loading file: " + resourcePath + " failed. Details : " + e.getMessage());
+        }
+        return resource;
     }
 }


### PR DESCRIPTION
First steps to perform different operations on label payload based on Spring events functionality, eventually to be replaced by event driven framework.